### PR TITLE
feat: Use new Eslint class instead of CLIEngine when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module.exports = {
 The options are:
 
 - `surfaceArea` — An array of files and/or directories to track. Use `[ "." ]` to track all Javascript files in the current directory. These files and directories are used if no files or directories are specified from the CLI
-- `eslint` — ESLint cli (CLIEngine) [options](https://eslint.org/docs/developer-guide/nodejs-api#cliengine).
+- `eslint` — ESLint class [options](https://eslint.org/docs/developer-guide/nodejs-api#-new-eslintoptions).
 - `rules` — An array of eslint rule names to track.
 - `write` — Corresponds to the negation of the `--no-write` CLI option. See [Command line options](#command-line-options).
 

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -87,12 +87,15 @@ it("should print message of EsplintError and exit with error code", () => {
   expect(process.exit).toHaveBeenCalledWith(1);
 });
 
-it("should print tip and exit with error code if there was an error", () => {
-  run.mockReturnValue({
+it("should print tip and exit with error code if there was an error", async () => {
+  const runPromise = Promise.resolve({
     results: [],
     hasError: true
   });
+  run.mockReturnValue(runPromise);
   cli([]);
+
+  await runPromise;
 
   expect(stripAnsi(log.log.mock.calls[0][0]).trim()).toEqual(
     "Use the --overwrite flag to ignore these errors and force the record to be rewritten."
@@ -100,26 +103,31 @@ it("should print tip and exit with error code if there was an error", () => {
   expect(process.exit).toHaveBeenCalledWith(1);
 });
 
-it("should show success message if no errors", () => {
-  run.mockReturnValue({
+it("should show success message if no errors", async () => {
+  const runPromise = Promise.resolve({
     results: [],
     hasError: false
   });
+  run.mockReturnValue(runPromise);
   cli([]);
+
+  await runPromise;
 
   expect(log.log).toHaveBeenCalledWith(log.createSuccess("Looking good!"));
 });
 
 it("should stage record file if flag is passed", async () => {
-  run.mockReturnValue({
+  const runPromise = Promise.resolve({
     results: [],
     hasError: false
   });
+  run.mockReturnValue(runPromise);
   const gitAddPromise = Promise.resolve();
   git().add.mockReturnValue(gitAddPromise);
 
   cli(["--stage-record-file"]);
 
+  await runPromise;
   await gitAddPromise;
 
   expect(log.log).toHaveBeenCalledWith(
@@ -132,8 +140,8 @@ it("should stage record file if flag is passed", async () => {
   expect(log.log).toHaveBeenCalledWith("Record file staged.");
 });
 
-it("should properly log the results", () => {
-  run.mockReturnValue({
+it("should properly log the results", async () => {
+  const runPromise = Promise.resolve({
     results: [
       {
         type: "error",
@@ -150,8 +158,11 @@ it("should properly log the results", () => {
     ],
     hasError: true
   });
+  run.mockReturnValue(runPromise);
 
   cli([]);
+
+  await runPromise;
 
   expect(log.error).toHaveBeenCalledWith(log.createError("this is an error"));
   expect(log.warn).toHaveBeenCalledWith(

--- a/__tests__/cli/suppress.test.js
+++ b/__tests__/cli/suppress.test.js
@@ -16,15 +16,23 @@ beforeEach(() => {
   log.warn.mockReset();
 });
 
-it("should pass files and a rule to suppress", () => {
+it("should pass files and a rule to suppress", async () => {
+  const suppressPromise = Promise.resolve();
+  suppress.mockReturnValue(suppressPromise);
   cli(["suppress", "no-console", "file", "file2"]);
+
+  await suppressPromise;
 
   expect(suppress).toHaveBeenCalledWith(["no-console"], ["file", "file2"]);
   expect(log.log).toHaveBeenCalledWith(log.createSuccess("Done!"));
 });
 
-it("should pass multiple rules to suppress", () => {
+it("should pass multiple rules to suppress", async () => {
+  const suppressPromise = Promise.resolve();
+  suppress.mockReturnValue(suppressPromise);
   cli(["suppress", '"no-console, semi"']);
+
+  await suppressPromise;
 
   expect(suppress).toHaveBeenCalledWith(["no-console", "semi"], []);
   expect(log.log).toHaveBeenCalledWith(log.createSuccess("Done!"));

--- a/__tests__/fileSet.test.js
+++ b/__tests__/fileSet.test.js
@@ -81,8 +81,8 @@ describe("compareFileSets", () => {
 describe("createFileSet", () => {
   process.cwd = () => "/absolute/path";
 
-  it("counts rule violations per file", () => {
-    const result = createFileSet(
+  it("counts rule violations per file", async () => {
+    const result = await createFileSet(
       [
         {
           filePath: "/absolute/path/foo.js",
@@ -116,8 +116,8 @@ describe("createFileSet", () => {
     });
   });
 
-  it("defaults give rules to 0", () => {
-    const result = createFileSet(
+  it("defaults give rules to 0", async () => {
+    const result = await createFileSet(
       [
         {
           filePath: "/absolute/path/foo.js",
@@ -149,8 +149,8 @@ describe("createFileSet", () => {
     });
   });
 
-  it("only tracks rules specified rules", () => {
-    const result = createFileSet(
+  it("only tracks rules specified rules", async () => {
+    const result = await createFileSet(
       [
         {
           filePath: "/absolute/path/foo.js",
@@ -179,8 +179,8 @@ describe("createFileSet", () => {
     });
   });
 
-  it("should unify windows- and posix paths into posix paths", () => {
-    const result = createFileSet(
+  it("should unify windows- and posix paths into posix paths", async () => {
+    const result = await createFileSet(
       [
         {
           filePath: "\\absolute\\path\\windows\\foo.js",

--- a/__tests__/integration/engine/suppress.test.js
+++ b/__tests__/integration/engine/suppress.test.js
@@ -13,9 +13,9 @@ describe("engine.suppress", () => {
 
   it(
     "should insert a disable-eslint comment before each violation",
-    setup("increase-warning", ({ fixturePath }) => {
+    setup("increase-warning", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-console"], ["."]);
+      await suppress(["no-console"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")
@@ -33,9 +33,9 @@ describe("engine.suppress", () => {
 
   it(
     "should handle no violations",
-    setup("increase-warning", ({ fixturePath }) => {
+    setup("increase-warning", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-extra-semi"], ["."]);
+      await suppress(["no-extra-semi"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")
@@ -46,9 +46,9 @@ describe("engine.suppress", () => {
 
   it(
     "should insert disable-eslint comment for multiple files",
-    setup("multiple-files-no-record", ({ fixturePath }) => {
+    setup("multiple-files-no-record", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-console"], ["."]);
+      await suppress(["no-console"], ["."]);
 
       ["index.js", "anotherFile.js"].forEach(filename => {
         const lines = readFile(fixturePath, filename)
@@ -68,9 +68,9 @@ describe("engine.suppress", () => {
 
   it(
     "should insert disable-eslint comment for multiple rules",
-    setup("extra-semi", ({ fixturePath }) => {
+    setup("extra-semi", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-console", "no-extra-semi"], ["."]);
+      await suppress(["no-console", "no-extra-semi"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")
@@ -85,9 +85,9 @@ describe("engine.suppress", () => {
 
   it(
     "should preserve existing disable-eslint comments",
-    setup("suppressed-extra-semi", ({ fixturePath }) => {
+    setup("suppressed-extra-semi", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-console", "no-extra-semi"], ["."]);
+      await suppress(["no-console", "no-extra-semi"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")
@@ -102,9 +102,9 @@ describe("engine.suppress", () => {
 
   it(
     "should preserve leading whitespace",
-    setup("new-file-with-error", ({ fixturePath }) => {
+    setup("new-file-with-error", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-console"], ["."]);
+      await suppress(["no-console"], ["."]);
 
       const lines = readFile(fixturePath, "newFile.js")
         .split("\n")
@@ -122,9 +122,9 @@ describe("engine.suppress", () => {
 
   it(
     "should only suppress the rules passed as arguments",
-    setup("extra-semi", ({ fixturePath }) => {
+    setup("extra-semi", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-extra-semi"], ["."]);
+      await suppress(["no-extra-semi"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")
@@ -139,9 +139,9 @@ describe("engine.suppress", () => {
 
   it(
     "should respect eslint configuration",
-    setup("config-with-globals", ({ fixturePath }) => {
+    setup("config-with-globals", async ({ fixturePath }) => {
       const { suppress } = require("../../../lib/engine");
-      suppress(["no-undef"], ["."]);
+      await suppress(["no-undef"], ["."]);
 
       const lines = readFile(fixturePath, "index.js")
         .split("\n")

--- a/__tests__/integration/fixtures/extra-semi/.esplintrc.js
+++ b/__tests__/integration/fixtures/extra-semi/.esplintrc.js
@@ -2,6 +2,6 @@ module.exports = {
   surfaceArea: ["."],
   rules: ["no-console"],
   eslint: {
-    configFile: "./.eslintrc.js"
+    overrideConfigFile: "./.eslintrc.js"
   }
 };

--- a/__tests__/integration/util.js
+++ b/__tests__/integration/util.js
@@ -30,9 +30,9 @@ function fixtureInit(id) {
 
   function setup(fixtureName, test) {
     const fixturePath = getFixturePath(fixtureName);
-    return (...args) => {
+    return async (...args) => {
       process.chdir(fixturePath);
-      test({ fixturePath }, ...args);
+      await test({ fixturePath }, ...args);
       resetFixturePath(fixtureName);
     };
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -156,12 +156,12 @@ function stats() {
   }
 }
 
-function suppress(argv) {
+async function suppress(argv) {
   try {
     const rules = argv.rule.split(",").map(r => r.trim());
     const files = getFiles(argv);
 
-    suppressRules(rules, files);
+    await suppressRules(rules, files);
     log.log(log.createSuccess("Done!"));
   } catch (error) {
     log.error(error);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -67,10 +67,10 @@ function cli(processArgv = process.argv.slice(2)) {
     }).argv;
 }
 
-function check(argv) {
+async function check(argv) {
   try {
     const options = getOptions(argv);
-    const { results, hasError } = run(options, getFiles(argv));
+    const { results, hasError } = await run(options, getFiles(argv));
     outputResults(results);
     if (hasError) {
       log.log(

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -26,7 +26,7 @@ const log = require("./log");
 const { getConfig } = require("./config");
 const fs = require("fs");
 
-function run(options, files) {
+async function run(options, files) {
   const config = getConfig(options);
   const oldRecord = getRecord(config);
   const cli = createCLIEngine(config.eslint);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -16,12 +16,7 @@ const {
   createRuleSet,
   createRuleStats
 } = require("./ruleSet");
-const {
-  createCLIEngine,
-  runLint,
-  getConfigForFile,
-  getWarningRules
-} = require("./eslint");
+const { creatEslintInstance, getWarningRules } = require("./eslint");
 const log = require("./log");
 const { getConfig } = require("./config");
 const fs = require("fs");
@@ -29,18 +24,17 @@ const fs = require("fs");
 async function run(options, files) {
   const config = getConfig(options);
   const oldRecord = getRecord(config);
-  const cli = createCLIEngine(config.eslint);
+  const eslint = creatEslintInstance(config.eslint);
 
   // Run Lint
-  const { results: lintResults } = runLint(
-    cli,
+  const lintResults = await eslint.runLint(
     getFiles({ files, config, isStartingOver: isRecordEmpty(oldRecord) })
   );
 
   // Create FileSet
   const oldFileSet = oldRecord.files;
-  const newFileSet = createFileSet(lintResults, config.rules, f =>
-    getWarningRules(getConfigForFile(cli, f))
+  const newFileSet = await createFileSet(lintResults, config.rules, async f =>
+    getWarningRules(await eslint.getConfigForFile(f))
   );
   const combinedFileSet = cleanUpDeletedFilesInFileSet(
     combineFileSets(oldRecord.files, newFileSet)
@@ -81,21 +75,23 @@ function getRuleStats() {
 }
 
 const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
-function suppress(ruleIds, files) {
+async function suppress(ruleIds, files) {
   const config = getConfig();
   const rules = ruleIds.reduce((rulesConfig, ruleId) => {
     rulesConfig[ruleId] = "warn";
     return rulesConfig;
   }, {});
 
-  const cli = createCLIEngine(
+  const eslint = creatEslintInstance(
     Object.assign({}, config.eslint, {
-      rules
+      overrideConfig: Object.assign({}, config.eslint.overrideConfig, {
+        rules
+      })
     })
   );
 
   // Run Lint
-  const { results: lintResults } = runLint(cli, getFiles({ files, config }));
+  const lintResults = await eslint.runLint(getFiles({ files, config }));
 
   lintResults
     .map(({ filePath, messages, source, output }) => {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -16,7 +16,11 @@ const {
   createRuleSet,
   createRuleStats
 } = require("./ruleSet");
-const { creatEslintInstance, getWarningRules } = require("./eslint");
+const {
+  creatEslintInstance,
+  getWarningRules,
+  overrideRulesConfig
+} = require("./eslint");
 const log = require("./log");
 const { getConfig } = require("./config");
 const fs = require("fs");
@@ -82,13 +86,7 @@ async function suppress(ruleIds, files) {
     return rulesConfig;
   }, {});
 
-  const eslint = creatEslintInstance(
-    Object.assign({}, config.eslint, {
-      overrideConfig: Object.assign({}, config.eslint.overrideConfig, {
-        rules
-      })
-    })
-  );
+  const eslint = creatEslintInstance(overrideRulesConfig(config.eslint, rules));
 
   // Run Lint
   const lintResults = await eslint.runLint(getFiles({ files, config }));

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -2,6 +2,7 @@ const CLIEngine = require("eslint").CLIEngine;
 const ESLint = require("eslint").ESLint;
 const chalk = require("chalk");
 const EsplintError = require("./EsplintError");
+const { merge } = require("lodash");
 
 function creatEslintInstance(eslintConfig) {
   if (ESLint) {
@@ -17,6 +18,20 @@ function creatEslintInstance(eslintConfig) {
     runLint: files => runLint(cli, files),
     getConfigForFile: file => getConfigForFile(cli, file)
   };
+}
+
+function overrideRulesConfig(config, rules) {
+  if (ESLint) {
+    return merge({}, config.eslint, {
+      overrideConfig: {
+        rules
+      }
+    });
+  } else {
+    return merge({}, config.eslint, {
+      rules
+    });
+  }
 }
 
 async function newRunLint(eslint, files) {
@@ -67,5 +82,6 @@ function getWarningRules({ rules }) {
 
 module.exports = {
   creatEslintInstance,
-  getWarningRules
+  getWarningRules,
+  overrideRulesConfig
 };

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1,12 +1,40 @@
 const CLIEngine = require("eslint").CLIEngine;
+const ESLint = require("eslint").ESLint;
 const chalk = require("chalk");
 const EsplintError = require("./EsplintError");
 
-function createCLIEngine(eslintConfig) {
-  return new CLIEngine(eslintConfig);
+function creatEslintInstance(eslintConfig) {
+  if (ESLint) {
+    const eslint = new ESLint(eslintConfig);
+    return {
+      runLint: files => newRunLint(eslint, files),
+      getConfigForFile: file => newGetConfigForFile(eslint, file)
+    };
+  }
+
+  const cli = new CLIEngine(eslintConfig);
+  return {
+    runLint: files => runLint(cli, files),
+    getConfigForFile: file => getConfigForFile(cli, file)
+  };
 }
 
-function runLint(eslintCli, files) {
+async function newRunLint(eslint, files) {
+  const results = await eslint.lintFiles(files);
+  const errorResults = ESLint.getErrorResults(results);
+  const hasErrors = Boolean(errorResults.length);
+  if (hasErrors) {
+    const formatter = await eslint.loadFormatter();
+    throw new EsplintError(
+      `There were some ESLint errors. Fix them and try again.\n${chalk.reset(
+        formatter.format(errorResults)
+      )}`
+    );
+  }
+  return results;
+}
+
+async function runLint(eslintCli, files) {
   const report = eslintCli.executeOnFiles(files);
   const errorReport = CLIEngine.getErrorResults(report.results);
   const hasErrors = Boolean(errorReport.length);
@@ -18,10 +46,14 @@ function runLint(eslintCli, files) {
       )}`
     );
   }
-  return report;
+  return report.results;
 }
 
-function getConfigForFile(cli, file) {
+function newGetConfigForFile(eslint, file) {
+  return eslint.calculateConfigForFile(file);
+}
+
+async function getConfigForFile(cli, file) {
   return cli.getConfigForFile(file);
 }
 
@@ -34,8 +66,6 @@ function getWarningRules({ rules }) {
 }
 
 module.exports = {
-  createCLIEngine,
-  runLint,
-  getConfigForFile,
+  creatEslintInstance,
   getWarningRules
 };

--- a/lib/fileSet.js
+++ b/lib/fileSet.js
@@ -3,34 +3,37 @@ const fs = require("fs");
 const chalk = require("chalk");
 const { toPosixPath, toSystemPath } = require("./pathUtils");
 
-function createFileSet(results, trackedRules, getWarnings) {
+async function createFileSet(results, trackedRules, getWarnings) {
   const fileSet = {};
   const trackedRuleSet = new Set(trackedRules);
 
-  results.forEach(({ messages, filePath }) => {
-    const relativePath = toPosixPath(
-      path.relative(process.cwd(), toSystemPath(filePath))
-    );
-    const rules = {};
+  await Promise.all(
+    results.map(async ({ messages, filePath }) => {
+      const relativePath = toPosixPath(
+        path.relative(process.cwd(), toSystemPath(filePath))
+      );
+      const rules = {};
 
-    if (getWarnings) {
-      getWarnings(relativePath).forEach(name => {
-        rules[name] = 0;
-      });
-    }
-
-    messages.forEach(({ ruleId }) => {
-      rules[ruleId] = (rules[ruleId] || 0) + 1;
-    });
-
-    Object.keys(rules).forEach(name => {
-      if (!trackedRuleSet.has(name)) {
-        delete rules[name];
+      if (getWarnings) {
+        const warnings = await getWarnings(relativePath);
+        warnings.forEach(name => {
+          rules[name] = 0;
+        });
       }
-    });
 
-    fileSet[relativePath] = rules;
-  });
+      messages.forEach(({ ruleId }) => {
+        rules[ruleId] = (rules[ruleId] || 0) + 1;
+      });
+
+      Object.keys(rules).forEach(name => {
+        if (!trackedRuleSet.has(name)) {
+          delete rules[name];
+        }
+      });
+
+      fileSet[relativePath] = rules;
+    })
+  );
 
   return fileSet;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -429,6 +429,69 @@
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+          "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1258,9 +1321,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "acorn-walk": {
@@ -1296,6 +1359,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -1788,12 +1857,6 @@
         }
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1855,12 +1918,6 @@
           "dev": true
         }
       }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "dev": true
     },
     "cliui": {
       "version": "6.0.0",
@@ -2714,6 +2771,15 @@
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2749,22 +2815,24 @@
       }
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz",
+      "integrity": "sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
@@ -2773,26 +2841,75 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -2802,14 +2919,104 @@
             "type-fest": "^0.8.1"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "import-fresh": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+          "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
           "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
+          }
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
           }
         },
         "type-fest": {
@@ -2817,6 +3024,15 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -2839,39 +3055,80 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
+        "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2889,9 +3146,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
@@ -3106,17 +3363,6 @@
             "is-plain-object": "^2.0.4"
           }
         }
-      }
-    },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4259,184 +4505,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
-    },
-    "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.11.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "figures": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "rxjs": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
-      }
     },
     "interpret": {
       "version": "1.4.0",
@@ -6949,12 +7017,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -7174,12 +7236,6 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -7644,9 +7700,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "remove-trailing-separator": {
@@ -7831,12 +7887,6 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
     },
     "run-node": {
@@ -8753,9 +8803,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -8816,9 +8866,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -8828,9 +8878,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "string-width": {
@@ -8924,15 +8974,6 @@
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         }
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -9170,9 +9211,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/hjylewis/esplint#readme",
   "devDependencies": {
-    "eslint": "^6.1.0",
+    "eslint": "^7.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jest": "^22.16.0",
     "execa": "^2.0.3",

--- a/scripts/postversion.js
+++ b/scripts/postversion.js
@@ -2,12 +2,12 @@ const { version } = require("../package");
 const fs = require("fs");
 const execa = require("execa");
 
-function updateExample() {
+async function updateExample() {
   process.chdir("./example");
 
   // Update .esplint.rec.json
   const { run } = require("../lib/engine");
-  run(
+  await run(
     {
       overwrite: true
     },


### PR DESCRIPTION
Fixes  #90

BREAKING CHANGE: esplint configuration property `eslint` now only accepts `Eslint` class options https://eslint.org/docs/developer-guide/nodejs-api#-new-eslintoption if using eslint@7+. 