### PR TITLE
fix: Allow stage on info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 .vscode
 .idea/
+*.swp

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -105,6 +105,24 @@ it("should print tip and exit with error code if there was an error", async () =
 
 it("should show success message if no errors", async () => {
   const runPromise = Promise.resolve({
+    results: [
+      {
+        type: "info",
+        message: "this is info"
+      }
+    ],
+    hasError: false
+  });
+  run.mockReturnValue(runPromise);
+  cli([]);
+
+  await runPromise;
+
+  expect(log.log).toHaveBeenCalledWith(log.createSuccess("Looking good!"));
+});
+
+it("should show success message if the only results are info types", async () => {
+  const runPromise = Promise.resolve({
     results: [],
     hasError: false
   });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -79,7 +79,7 @@ async function check(argv) {
         )} flag to ignore these errors and force the record to be rewritten.`
       );
       process.exit(1);
-    } else if (results.length === 0) {
+    } else if (results.filter(({ type }) => type !== 'info').length === 0) {
       log.log(log.createSuccess("Looking good!"));
 
       if (options.stageRecordFile) {


### PR DESCRIPTION
Allow `--stage-record-file` to work when there are only info messages or no messages. Currently, if info messages print out at the end, the `results.length` is `>0` so the `.esplint.rec.json` file does not get staged. IMO, in this case, validation passed so the file should get staged as normal.