### PR TITLE
feat: Add compact mode for stats cli command

### DIFF
--- a/__tests__/cli/stats.test.js
+++ b/__tests__/cli/stats.test.js
@@ -17,6 +17,36 @@ beforeEach(() => {
   log.warn.mockReset();
 });
 
+const mockedRuleStatsWithViolations = {
+  "no-console": {
+    count: 2,
+    files: ["index.js", "not-index.js"]
+  },
+  "other-rule": {
+    count: 100,
+    files: ["file.js", "other-file.js", "other-other-file.js"]
+  },
+  "no-violations": {
+    count: 0,
+    files: []
+  }
+};
+
+const mockedRuleStatsWithoutViolations = {
+  "no-console": {
+    count: 0,
+    files: []
+  },
+  "other-rule": {
+    count: 0,
+    files: []
+  },
+  "no-violations": {
+    count: 0,
+    files: []
+  }
+};
+
 it("should print warning when record file doesn't exist", () => {
   getRuleStats.mockReturnValue(null);
   cli(["stats"]);
@@ -29,20 +59,7 @@ it("should print warning when record file doesn't exist", () => {
 });
 
 it("should print the count and list files per rule", () => {
-  getRuleStats.mockReturnValue({
-    "no-console": {
-      count: 2,
-      files: ["index.js", "not-index.js"]
-    },
-    "other-rule": {
-      count: 100,
-      files: ["file.js", "other-file.js", "other-other-file.js"]
-    },
-    "no-violations": {
-      count: 0,
-      files: []
-    }
-  });
+  getRuleStats.mockReturnValue(mockedRuleStatsWithViolations);
   cli(["stats"]);
 
   expect(log.log).toHaveBeenCalled();
@@ -73,20 +90,7 @@ it("should print the count and list files per rule", () => {
 });
 
 it("should print the count and list files per rule", () => {
-  getRuleStats.mockReturnValue({
-    "no-console": {
-      count: 0,
-      files: []
-    },
-    "other-rule": {
-      count: 0,
-      files: []
-    },
-    "no-violations": {
-      count: 0,
-      files: []
-    }
-  });
+  getRuleStats.mockReturnValue(mockedRuleStatsWithoutViolations);
   cli(["stats"]);
 
   expect(log.log).toHaveBeenCalled();
@@ -104,6 +108,52 @@ it("should print the count and list files per rule", () => {
 
     /"other-rule": 0/,
     /No files/,
+
+    /No violations!/
+  ];
+
+  output.forEach((line, i) => {
+    expect(line).toMatch(expectedOutput[i]);
+  });
+});
+
+it("should print the count and list files per rule in compact mode", () => {
+  getRuleStats.mockReturnValue(mockedRuleStatsWithViolations);
+  cli(["stats", "--compact"]);
+
+  expect(log.log).toHaveBeenCalled();
+  const output = stripAnsi(log.log.mock.calls[0][0])
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => l.length > 0);
+
+  const expectedOutput = [
+    /"no-console": 2/,
+    /"no-violations": 0/,
+    /"other-rule": 100/,
+
+    /Total: 102/
+  ];
+
+  output.forEach((line, i) => {
+    expect(line).toMatch(expectedOutput[i]);
+  });
+});
+
+it("should print the count and list files per rule in compact mode", () => {
+  getRuleStats.mockReturnValue(mockedRuleStatsWithoutViolations);
+  cli(["stats", "--compact"]);
+
+  expect(log.log).toHaveBeenCalled();
+  const output = stripAnsi(log.log.mock.calls[0][0])
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => l.length > 0);
+
+  const expectedOutput = [
+    /"no-console": 0/,
+    /"no-violations": 0/,
+    /"other-rule": 0/,
 
     /No violations!/
   ];

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,9 +39,14 @@ function cli(processArgv = process.argv.slice(2)) {
     .command(
       "stats",
       "Print stats about eslint violations",
-      () => {},
-      () => {
-        stats();
+      y =>
+        y.option("compact", {
+          default: "false",
+          describe: "Only prints the violated rules without",
+          type: "boolean"
+        }),
+      argv => {
+        stats(argv);
       }
     )
     .command(
@@ -79,7 +84,7 @@ async function check(argv) {
         )} flag to ignore these errors and force the record to be rewritten.`
       );
       process.exit(1);
-    } else if (results.filter(({ type }) => type !== 'info').length === 0) {
+    } else if (results.filter(({ type }) => type !== "info").length === 0) {
       log.log(log.createSuccess("Looking good!"));
 
       if (options.stageRecordFile) {
@@ -97,7 +102,7 @@ async function check(argv) {
   }
 }
 
-function stats() {
+function stats(argv) {
   try {
     const ruleStats = getRuleStats();
     if (ruleStats === null) {
@@ -113,7 +118,9 @@ function stats() {
       .map(rule => ruleStats[rule].count)
       .reduce((a, b) => a + b, 0);
 
-    const output = Object.keys(ruleStats)
+    const { compact } = argv;
+
+    let output = Object.keys(ruleStats)
       .sort()
       .map(rule => {
         const ruleOutput = [];
@@ -129,6 +136,10 @@ function stats() {
           );
         }
 
+        if (compact) {
+          return ruleOutput;
+        }
+
         if (files.length === 0) {
           ruleOutput.push(` ${chalk.italic.dim("No files")}`);
         } else {
@@ -138,9 +149,13 @@ function stats() {
         }
 
         return ruleOutput;
-      })
-      .reduce((a, b) => a.concat("").concat(b), [])
-      .concat("")
+      });
+
+    if (!compact) {
+      output = output.reduce((a, b) => a.concat("").concat(b), []).concat("");
+    }
+
+    output = output
       .concat("")
       .concat(
         totalCount === 0

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -102,7 +102,7 @@ async function check(argv) {
   }
 }
 
-function stats(argv) {
+function stats({ compact }) {
   try {
     const ruleStats = getRuleStats();
     if (ruleStats === null) {
@@ -117,8 +117,6 @@ function stats(argv) {
     const totalCount = Object.keys(ruleStats)
       .map(rule => ruleStats[rule].count)
       .reduce((a, b) => a + b, 0);
-
-    const { compact } = argv;
 
     let output = Object.keys(ruleStats)
       .sort()

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,7 +42,7 @@ function cli(processArgv = process.argv.slice(2)) {
       y =>
         y.option("compact", {
           default: "false",
-          describe: "Only prints the violated rules without",
+          describe: "Only prints the violated rules without listing the files",
           type: "boolean"
         }),
       argv => {


### PR DESCRIPTION
This Pull Request:
- adds compact mode for the stats command by adding `--compact`option

![Bildschirmfoto 2021-02-06 um 01 29 52](https://user-images.githubusercontent.com/5724535/107102463-d19b8200-681a-11eb-832a-684c06f919d0.png)

Closes https://github.com/hjylewis/esplint/issues/98