### PR TITLE
fix: Improve performance of `createRuleStats`

### DIFF
--- a/lib/ruleSet.js
+++ b/lib/ruleSet.js
@@ -26,7 +26,7 @@ function createRuleStats(fileSet, rules) {
       }
 
       ruleStats[ruleName].count = ruleStats[ruleName].count + ruleCount;
-      ruleStats[ruleName].files = ruleStats[ruleName].files.concat(fileName);
+      ruleStats[ruleName].files.push(fileName);
     });
   });
 


### PR DESCRIPTION
We don't need to keep the `files` immutable when building up this object. By pushing onto the arrays, I was able to see runtime improve by ~70%. When a fully cached repo is fully linted, I went from a total runtime of 28.2s to 7.6s.